### PR TITLE
Add clock weather card support

### DIFF
--- a/src/template.yaml
+++ b/src/template.yaml
@@ -39,10 +39,11 @@ app-header-edit-text-color: var(--token-color-text-primary)
 # Main interface colors
 primary-color: var(--token-color-primary)
 dark-primary-color: var(--primary-color)
-light-primary-color: var(--primary-color)
+light-primary-color: var(--token-light-primary-color)
 accent-color: var(--token-color-accent)
 divider-color: var(--token-color-background-divider)
 scrollbar-thumb-color: var(--token-color-background-scrollbar-thumb)
+disabled-color: var(--token-color-disabled)
 
 # Feedback colors
 info-color: var(--token-color-feedback-info)

--- a/src/tokens_dark.yaml
+++ b/src/tokens_dark.yaml
@@ -27,6 +27,8 @@ token-rgb-state-inactive: 123, 126, 139
 
 token-color-primary: rgb(var(--token-rgb-primary))
 token-color-accent: var(--token-color-primary)
+token-color-disabled: rgba(255, 255, 255, 0.2)
+token-light-primary-color: rgb(105 124 144)
 
 token-color-feedback-info: rgb(39, 209, 246)
 token-color-feedback-warning: rgb(255, 219, 117)

--- a/src/tokens_light.yaml
+++ b/src/tokens_light.yaml
@@ -27,6 +27,8 @@ token-rgb-state-inactive: 176, 190, 197
 
 token-color-primary: rgb(var(--token-rgb-primary))
 token-color-accent: var(--token-color-primary)
+token-color-disabled: rgb(173 176 184)
+token-light-primary-color: rgb(167 182 199)
 
 token-color-feedback-info: rgb(39, 209, 246)
 token-color-feedback-warning: rgb(255, 219, 117)


### PR DESCRIPTION
With this update, I aim to add support for the [clock-weather-card](https://github.com/pkissling/clock-weather-card) and to introduce a customizable `disabled-color`.

This change modifies both the `disabled-color` and `light-primary-color`, which might cause unexpected side effects. While my reference test views haven't shown any issues, it’s challenging to fully predict color usage across all plugins and componentes. I’m optimistic that this will look good overall. In terms of contrast, everything should be alright, though some aesthetic inconsistencies might appear.

---

## Dark Theme

### Before
![Screenshot 2024-11-12 at 20 29 57](https://github.com/user-attachments/assets/9ac9a9b0-aacf-40e2-ab24-3a565eb4b929)

### After
![Screenshot 2024-11-12 at 20 30 22](https://github.com/user-attachments/assets/fa36c146-5233-4b69-9d3e-1a3ef9f411bc)

## Light Theme
### Before
![Screenshot 2024-11-12 at 20 35 10](https://github.com/user-attachments/assets/9a7295d8-42af-4d05-9926-ea8ebf5dfed5)

### After
![Screenshot 2024-11-12 at 20 34 54](https://github.com/user-attachments/assets/6cd4deaa-2e50-4c09-a20c-0d29e1f13334)

